### PR TITLE
Create login screen and deploy packaging workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ lerna-debug.log*
 node_modules
 dist
 dist-ssr
+deploy
 *.local
 
 # Editor directories and files

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "dev": "vite",
     "build": "vite build",
     "build:dev": "vite build --mode development",
+    "package:deploy": "npm run build && node scripts/create-deploy-package.mjs",
     "lint": "eslint .",
     "preview": "vite preview"
   },

--- a/scripts/create-deploy-package.mjs
+++ b/scripts/create-deploy-package.mjs
@@ -1,0 +1,46 @@
+import { existsSync, mkdirSync, rmSync, statSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { spawnSync } from "node:child_process";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const rootDir = resolve(__dirname, "..");
+const distDir = join(rootDir, "dist");
+
+if (!existsSync(distDir)) {
+  console.error("Build output not found. Run `npm run build` before packaging.");
+  process.exit(1);
+}
+
+const deployDir = join(rootDir, "deploy");
+if (!existsSync(deployDir)) {
+  mkdirSync(deployDir, { recursive: true });
+}
+
+const timestamp = new Date()
+  .toISOString()
+  .replace(/[:T]/g, "-")
+  .replace(/\..+/, "");
+const packageName = `conversa-mestre-${timestamp}.tar.gz`;
+const outputPath = join(deployDir, packageName);
+
+if (existsSync(outputPath)) {
+  rmSync(outputPath);
+}
+
+const result = spawnSync("tar", ["-czf", outputPath, "-C", distDir, "."], { stdio: "inherit" });
+
+if (result.error) {
+  console.error("Failed to run tar command:", result.error);
+  process.exit(1);
+}
+
+if (result.status !== 0) {
+  console.error(`tar process exited with code ${result.status}`);
+  process.exit(result.status ?? 1);
+}
+
+const { size } = statSync(outputPath);
+const sizeInMb = (size / (1024 * 1024)).toFixed(2);
+console.log(`Deploy package created: ${packageName} (${sizeInMb} MB)`);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import { TooltipProvider } from "@/components/ui/tooltip";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import Index from "./pages/Index";
+import Login from "./pages/Login";
 import NotFound from "./pages/NotFound";
 
 const queryClient = new QueryClient();
@@ -15,7 +16,8 @@ const App = () => (
       <Sonner />
       <BrowserRouter>
         <Routes>
-          <Route path="/" element={<Index />} />
+          <Route path="/" element={<Login />} />
+          <Route path="/dashboard" element={<Index />} />
           {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
           <Route path="*" element={<NotFound />} />
         </Routes>

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -20,7 +20,7 @@ const badgeVariants = cva(
   },
 );
 
-export interface BadgeProps extends React.HTMLAttributes<HTMLDivElement>, VariantProps<typeof badgeVariants> {}
+export type BadgeProps = React.HTMLAttributes<HTMLDivElement> & VariantProps<typeof badgeVariants>;
 
 function Badge({ className, variant, ...props }: BadgeProps) {
   return <div className={cn(badgeVariants({ variant }), className)} {...props} />;

--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -21,7 +21,7 @@ const Command = React.forwardRef<
 ));
 Command.displayName = CommandPrimitive.displayName;
 
-interface CommandDialogProps extends DialogProps {}
+type CommandDialogProps = DialogProps;
 
 const CommandDialog = ({ children, ...props }: CommandDialogProps) => {
   return (

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 
 import { cn } from "@/lib/utils";
 
-export interface TextareaProps extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+export type TextareaProps = React.TextareaHTMLAttributes<HTMLTextAreaElement>;
 
 const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(({ className, ...props }, ref) => {
   return (

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -1,0 +1,95 @@
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { Bot, LockKeyhole } from "lucide-react";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+
+const Login = () => {
+  const navigate = useNavigate();
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setIsSubmitting(true);
+
+    window.setTimeout(() => {
+      setIsSubmitting(false);
+      navigate("/dashboard");
+    }, 1200);
+  };
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-background via-background to-primary/15 flex flex-col md:flex-row">
+      <div className="hidden md:flex md:w-1/2 bg-primary/10 backdrop-blur-xl relative overflow-hidden">
+        <div className="absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(255,255,255,0.12),_transparent_60%)]" />
+        <div className="relative z-10 flex flex-col justify-center p-12 text-primary-foreground/80">
+          <div className="flex items-center gap-3 text-primary">
+            <Bot className="h-9 w-9" />
+            <span className="text-lg font-semibold uppercase tracking-[0.3em]">Conversa Mestre</span>
+          </div>
+          <h1 className="mt-10 text-4xl font-bold text-foreground">
+            Inteligência conversacional para equipes de alta performance
+          </h1>
+          <p className="mt-6 text-base text-muted-foreground max-w-lg">
+            Acesse o painel para configurar perfis especialistas, acompanhar métricas em tempo real e garantir um
+            atendimento excepcional no WhatsApp com tecnologia RAG.
+          </p>
+          <div className="mt-10 grid grid-cols-2 gap-6 text-sm text-muted-foreground">
+            <div className="space-y-2">
+              <div className="flex items-center gap-2 text-foreground font-medium">
+                <LockKeyhole className="h-5 w-5 text-primary" />
+                Segurança corporativa
+              </div>
+              <p>Acesso protegido e controle de permissões para toda a equipe.</p>
+            </div>
+            <div className="space-y-2">
+              <div className="flex items-center gap-2 text-foreground font-medium">
+                <Bot className="h-5 w-5 text-primary" />
+                Perfis inteligentes
+              </div>
+              <p>Configure especialistas virtuais com conhecimento contextualizado.</p>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div className="flex flex-1 items-center justify-center p-6 md:p-12">
+        <Card className="w-full max-w-md shadow-2xl border-border/60 bg-background/80 backdrop-blur-xl">
+          <CardHeader>
+            <CardTitle className="text-2xl font-bold">Acesse sua conta</CardTitle>
+            <CardDescription>
+              Entre com suas credenciais corporativas para acessar o painel Conversa Mestre
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <form className="space-y-6" onSubmit={handleSubmit}>
+              <div className="space-y-2">
+                <Label htmlFor="email">Email</Label>
+                <Input id="email" type="email" placeholder="voce@empresa.com" required autoComplete="email" />
+              </div>
+              <div className="space-y-2">
+                <div className="flex items-center justify-between">
+                  <Label htmlFor="password">Senha</Label>
+                  <button type="button" className="text-sm text-primary hover:underline">
+                    Esqueceu a senha?
+                  </button>
+                </div>
+                <Input id="password" type="password" placeholder="••••••••" required autoComplete="current-password" />
+              </div>
+              <Button type="submit" className="w-full" disabled={isSubmitting}>
+                {isSubmitting ? "Entrando..." : "Entrar"}
+              </Button>
+            </form>
+            <p className="mt-6 text-sm text-muted-foreground text-center">
+              Não tem acesso? <span className="text-primary font-medium">Entre em contato com o administrador.</span>
+            </p>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+};
+
+export default Login;

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,4 +1,5 @@
 import type { Config } from "tailwindcss";
+import tailwindcssAnimate from "tailwindcss-animate";
 
 export default {
   darkMode: ["class"],
@@ -106,5 +107,5 @@ export default {
       },
     },
   },
-  plugins: [require("tailwindcss-animate")],
+  plugins: [tailwindcssAnimate],
 } satisfies Config;


### PR DESCRIPTION
## Summary
- add a dedicated login page and update routing so the dashboard lives under /dashboard
- provide a build packaging command that creates a compressed artifact and ignore the generated directory
- resolve lint issues by switching empty interfaces to type aliases and adopting an ESM Tailwind plugin import

## Testing
- npm run lint
- npm run package:deploy

------
https://chatgpt.com/codex/tasks/task_e_68cb35f0c47c832c8633a1d56cd5a328